### PR TITLE
Bump mongo-client.version from 4.3.4 to 4.6.0 BOT TEST PR

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -156,7 +156,7 @@
         <liquibase.version>4.9.1</liquibase.version>
         <snakeyaml.version>1.30</snakeyaml.version>
         <osgi.version>6.0.0</osgi.version>
-        <mongo-client.version>4.3.4</mongo-client.version>
+        <mongo-client.version>4.6.0</mongo-client.version>
         <mongo-crypt.version>1.2.1</mongo-crypt.version>
         <proton-j.version>0.33.10</proton-j.version>
         <okhttp.version>3.14.9</okhttp.version>


### PR DESCRIPTION
Bumps `mongo-client.version` from 4.3.4 to 4.6.0.

Updates `mongodb-driver-sync` from 4.3.4 to 4.6.0
- [Release notes](https://github.com/mongodb/mongo-java-driver/releases)
- [Commits](https://github.com/mongodb/mongo-java-driver/compare/r4.3.4...r4.6.0)

Updates `mongodb-driver-core` from 4.3.4 to 4.6.0
- [Release notes](https://github.com/mongodb/mongo-java-driver/releases)
- [Commits](https://github.com/mongodb/mongo-java-driver/compare/r4.3.4...r4.6.0)

Updates `mongodb-driver-legacy` from 4.3.4 to 4.6.0
- [Release notes](https://github.com/mongodb/mongo-java-driver/releases)
- [Commits](https://github.com/mongodb/mongo-java-driver/compare/r4.3.4...r4.6.0)

Updates `mongodb-driver-reactivestreams` from 4.3.4 to 4.6.0
- [Release notes](https://github.com/mongodb/mongo-java-driver/releases)
- [Commits](https://github.com/mongodb/mongo-java-driver/compare/r4.3.4...r4.6.0)

Updates `bson` from 4.3.4 to 4.6.0
- [Release notes](https://github.com/mongodb/mongo-java-driver/releases)
- [Commits](https://github.com/mongodb/mongo-java-driver/compare/r4.3.4...r4.6.0)

---
updated-dependencies:
- dependency-name: org.mongodb:mongodb-driver-sync
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: org.mongodb:mongodb-driver-core
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: org.mongodb:mongodb-driver-legacy
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: org.mongodb:mongodb-driver-reactivestreams
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: org.mongodb:bson
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>