### PR TITLE
Update action-download-artifact

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,12 +23,11 @@ jobs:
       - name: Restore mtime
         run: git restore-mtime
 
-      # There is a weird issue with download-artifact@v4
-      # keeping the external action for now
       - name: Download PR Artifact
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v6
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
+          run_id: ${{ github.event.workflow_run.id }}
           workflow_conclusion: success
           name: documentation
           path: documentation-temp


### PR DESCRIPTION
There was a breaking change from version 3 to 4 of the dawidd6 action-download-artifact, but I have identified a workaround. 

This PR cannot be properly tested until after the merge, and even then it only affects documentation builds.